### PR TITLE
Bump poi from 3.17 to 4.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
   	<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi</artifactId>
-			<version>3.17</version>
+			<version>4.1.1</version>
 		</dependency>
 
 


### PR DESCRIPTION
Bumps poi from 3.17 to 4.1.1.

---
updated-dependencies:
- dependency-name: org.apache.poi:poi
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>